### PR TITLE
Shorter naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 require 'interface_comparator'
 # check if two objects has the same interface
 # including public methods list and their arity
-InterfaceComparator.interfaces_are_same?(a, b) # => true or false
+InterfaceComparator.same?(a, b) # => true or false
 
 # see detailed list of difference between interfaces
 # of two objects

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ InterfaceComparator.same?(a, b) # => true or false
 
 # see detailed list of difference between interfaces
 # of two objects
-InterfaceComparator.diff_interfaces(a, b)
+InterfaceComparator.diff(a, b)
 # if there are difference between methods
 # it will return them in aa array of hashes:
 #[{
@@ -58,7 +58,7 @@ assert_equal_interfaces a, b
 refute_equal_interfaces a, b
 ```
 
-Output in case of failure will be similar to those in diff_interfaces.
+Output in case of failure will be similar to those in diff.
 
 ## Development
 

--- a/lib/interface_comparator.rb
+++ b/lib/interface_comparator.rb
@@ -5,11 +5,11 @@ require 'interface_comparator/version'
 module InterfaceComparator
   # is the interface of this two objects are the same?
   def self.same?(a, b)
-    diff_interfaces(a, b).empty?
+    diff(a, b).empty?
   end
 
   # show me the difference between interface of these two objects
-  def self.diff_interfaces(a, b)
+  def self.diff(a, b)
     methods_diff = diff_methods(a, b)
     return methods_diff unless methods_diff.empty?
     arity_diff = methods_arity_diff(a, b)

--- a/lib/interface_comparator.rb
+++ b/lib/interface_comparator.rb
@@ -4,7 +4,7 @@ require 'interface_comparator/version'
 # including public methods list and their arity
 module InterfaceComparator
   # is the interface of this two objects are the same?
-  def self.interfaces_are_same?(a, b)
+  def self.same?(a, b)
     diff_interfaces(a, b).empty?
   end
 

--- a/lib/interface_comparator/minitest.rb
+++ b/lib/interface_comparator/minitest.rb
@@ -4,7 +4,7 @@ module Minitest::Assertions
   #
   def assert_equal_interfaces(object_a, object_b)
     assert InterfaceComparator.same?(object_a, object_b),
-      "Interfaces are not the same: #{InterfaceComparator.diff_interfaces(object_a, object_b)}"
+      "Interfaces are not the same: #{InterfaceComparator.diff(object_a, object_b)}"
   end
 
   #

--- a/lib/interface_comparator/minitest.rb
+++ b/lib/interface_comparator/minitest.rb
@@ -3,7 +3,7 @@ module Minitest::Assertions
   #  Fails unless +object_a and +object_a have the same interfaces (in terms of method and their arity).
   #
   def assert_equal_interfaces(object_a, object_b)
-    assert InterfaceComparator.interfaces_are_same?(object_a, object_b),
+    assert InterfaceComparator.same?(object_a, object_b),
       "Interfaces are not the same: #{InterfaceComparator.diff_interfaces(object_a, object_b)}"
   end
 
@@ -11,7 +11,7 @@ module Minitest::Assertions
   #  Fails if +object_a and +object_a have the same interfaces (in terms of method and their arity).
   #
   def refute_equal_interfaces(object_a, object_b)
-    refute InterfaceComparator.interfaces_are_same?(object_a, object_b),
+    refute InterfaceComparator.same?(object_a, object_b),
       "Interfaces are of these two object are the same"
   end
 end

--- a/test/interface_comparator_test.rb
+++ b/test/interface_comparator_test.rb
@@ -8,7 +8,7 @@ class InterfaceComparatorTest < Minitest::Test
   def test_correct_public_interface
     unique_public_methods = (InterfaceComparator.public_methods -
                             Module.public_methods).sort
-    assert_equal %i(same? diff_interfaces).sort,
+    assert_equal %i(same? diff).sort,
                  unique_public_methods
   end
 
@@ -30,7 +30,7 @@ class InterfaceComparatorTest < Minitest::Test
     a.instance_eval 'def new_method; end'
     assert !InterfaceComparator.same?(a, b)
     assert_equal method_hash_factory(:new_method, true, false),
-                 InterfaceComparator.diff_interfaces(a, b)
+                 InterfaceComparator.diff(a, b)
   end
 
   def test_it_show_correct_method_difference_opposite_way
@@ -39,7 +39,7 @@ class InterfaceComparatorTest < Minitest::Test
     b.instance_eval 'def new_method; end'
     assert !InterfaceComparator.same?(a, b)
     assert_equal method_hash_factory(:new_method, false, true),
-                 InterfaceComparator.diff_interfaces(a, b)
+                 InterfaceComparator.diff(a, b)
   end
 
   def test_it_show_correct_method_arity_difference
@@ -49,7 +49,7 @@ class InterfaceComparatorTest < Minitest::Test
     b.instance_eval 'def new_method(a); end'
     assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 0, 1),
-                 InterfaceComparator.diff_interfaces(a, b)
+                 InterfaceComparator.diff(a, b)
   end
 
   def test_it_show_correct_method_arity_difference_opposite_way
@@ -59,7 +59,7 @@ class InterfaceComparatorTest < Minitest::Test
     b.instance_eval 'def new_method; end'
     assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 1, 0),
-                 InterfaceComparator.diff_interfaces(a, b)
+                 InterfaceComparator.diff(a, b)
   end
 
   def test_it_show_correct_method_arity_difference_with_args
@@ -69,7 +69,7 @@ class InterfaceComparatorTest < Minitest::Test
     b.instance_eval 'def new_method; end'
     assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, -1, 0),
-                 InterfaceComparator.diff_interfaces(a, b)
+                 InterfaceComparator.diff(a, b)
   end
 
   def test_it_show_correct_method_arity_difference_with_args_opposite_way
@@ -79,7 +79,7 @@ class InterfaceComparatorTest < Minitest::Test
     b.instance_eval 'def new_method(*args); end'
     assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 0, -1),
-                 InterfaceComparator.diff_interfaces(a, b)
+                 InterfaceComparator.diff(a, b)
   end
 
   def test_it_show_correct_method_arity_difference_with_named_args
@@ -89,7 +89,7 @@ class InterfaceComparatorTest < Minitest::Test
     b.instance_eval 'def new_method; end'
     assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 1, 0),
-                 InterfaceComparator.diff_interfaces(a, b)
+                 InterfaceComparator.diff(a, b)
   end
 
   def test_it_show_correct_method_arity_difference_with_named_args_opposite_way
@@ -99,7 +99,7 @@ class InterfaceComparatorTest < Minitest::Test
     b.instance_eval 'def new_method(args:); end'
     assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 0, 1),
-                 InterfaceComparator.diff_interfaces(a, b)
+                 InterfaceComparator.diff(a, b)
   end
 
   def test_it_show_correct_method_arity_for_c_methods

--- a/test/interface_comparator_test.rb
+++ b/test/interface_comparator_test.rb
@@ -8,27 +8,27 @@ class InterfaceComparatorTest < Minitest::Test
   def test_correct_public_interface
     unique_public_methods = (InterfaceComparator.public_methods -
                             Module.public_methods).sort
-    assert_equal %i(interfaces_are_same? diff_interfaces).sort,
+    assert_equal %i(same? diff_interfaces).sort,
                  unique_public_methods
   end
 
   def test_it_does_not_show_difference_for_two_same_objects
     a = Object.new
     b = Object.new
-    assert InterfaceComparator.interfaces_are_same?(a, b)
+    assert InterfaceComparator.same?(a, b)
   end
 
   def test_it_show_method_difference_for_two_very_different_object
     a = Object.new
     b = ''
-    assert !InterfaceComparator.interfaces_are_same?(a, b)
+    assert !InterfaceComparator.same?(a, b)
   end
 
   def test_it_show_correct_method_difference
     a = Object.new
     b = Object.new
     a.instance_eval 'def new_method; end'
-    assert !InterfaceComparator.interfaces_are_same?(a, b)
+    assert !InterfaceComparator.same?(a, b)
     assert_equal method_hash_factory(:new_method, true, false),
                  InterfaceComparator.diff_interfaces(a, b)
   end
@@ -37,7 +37,7 @@ class InterfaceComparatorTest < Minitest::Test
     a = Object.new
     b = Object.new
     b.instance_eval 'def new_method; end'
-    assert !InterfaceComparator.interfaces_are_same?(a, b)
+    assert !InterfaceComparator.same?(a, b)
     assert_equal method_hash_factory(:new_method, false, true),
                  InterfaceComparator.diff_interfaces(a, b)
   end
@@ -47,7 +47,7 @@ class InterfaceComparatorTest < Minitest::Test
     b = Object.new
     a.instance_eval 'def new_method; end'
     b.instance_eval 'def new_method(a); end'
-    assert !InterfaceComparator.interfaces_are_same?(a, b)
+    assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 0, 1),
                  InterfaceComparator.diff_interfaces(a, b)
   end
@@ -57,7 +57,7 @@ class InterfaceComparatorTest < Minitest::Test
     b = Object.new
     a.instance_eval 'def new_method(a); end'
     b.instance_eval 'def new_method; end'
-    assert !InterfaceComparator.interfaces_are_same?(a, b)
+    assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 1, 0),
                  InterfaceComparator.diff_interfaces(a, b)
   end
@@ -67,7 +67,7 @@ class InterfaceComparatorTest < Minitest::Test
     b = Object.new
     a.instance_eval 'def new_method(*args); end'
     b.instance_eval 'def new_method; end'
-    assert !InterfaceComparator.interfaces_are_same?(a, b)
+    assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, -1, 0),
                  InterfaceComparator.diff_interfaces(a, b)
   end
@@ -77,7 +77,7 @@ class InterfaceComparatorTest < Minitest::Test
     b = Object.new
     a.instance_eval 'def new_method; end'
     b.instance_eval 'def new_method(*args); end'
-    assert !InterfaceComparator.interfaces_are_same?(a, b)
+    assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 0, -1),
                  InterfaceComparator.diff_interfaces(a, b)
   end
@@ -87,7 +87,7 @@ class InterfaceComparatorTest < Minitest::Test
     b = Object.new
     a.instance_eval 'def new_method(args:); end'
     b.instance_eval 'def new_method; end'
-    assert !InterfaceComparator.interfaces_are_same?(a, b)
+    assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 1, 0),
                  InterfaceComparator.diff_interfaces(a, b)
   end
@@ -97,7 +97,7 @@ class InterfaceComparatorTest < Minitest::Test
     b = Object.new
     a.instance_eval 'def new_method; end'
     b.instance_eval 'def new_method(args:); end'
-    assert !InterfaceComparator.interfaces_are_same?(a, b)
+    assert !InterfaceComparator.same?(a, b)
     assert_equal arity_hash_factory(:new_method, 0, 1),
                  InterfaceComparator.diff_interfaces(a, b)
   end
@@ -106,6 +106,6 @@ class InterfaceComparatorTest < Minitest::Test
     a = Object.new
     a.instance_eval 'def sumThem(a, b); end'
     b = CHello.new
-    assert InterfaceComparator.interfaces_are_same?(a, b)
+    assert InterfaceComparator.same?(a, b)
   end
 end


### PR DESCRIPTION
The name `InterfaceComparator` sends a very strong signal that the thing it compares are interfaces, so IMHO there’s no need to repeat that in the function names. 😉 